### PR TITLE
fix: handling TableSummary scroll error when data is empty

### DIFF
--- a/src/components/table/table.vue
+++ b/src/components/table/table.vue
@@ -770,7 +770,7 @@
                 if (this.showHeader) this.$refs.header.scrollLeft = event.target.scrollLeft;
                 if (this.isLeftFixed) this.$refs.fixedBody.scrollTop = event.target.scrollTop;
                 if (this.isRightFixed) this.$refs.fixedRightBody.scrollTop = event.target.scrollTop;
-                if (this.showSummary) this.$refs.summary.$el.scrollLeft = event.target.scrollLeft;
+                if (this.showSummary && (this.data && this.data.length)) this.$refs.summary.$el.scrollLeft = event.target.scrollLeft;
                 this.hideColumnFilter();
             },
             handleFixedMousewheel(event) {


### PR DESCRIPTION
fix horizontally scrolling Table error when data is empty. When `data` prop is empty, `tableSummary` component isn't rendered, but `handleBodyScroll` method refer `tableSummary` component's `scrollLeft` property.