### PR TITLE
fix: 删除最后一个Tree节点时报错

### DIFF
--- a/src/components/tree/tree.vue
+++ b/src/components/tree/tree.vue
@@ -171,6 +171,7 @@
                 }
             },
             handleSelect (nodeKey) {
+                if (!this.flatState[nodeKey]) return
                 const node = this.flatState[nodeKey].node;
                 if (!this.multiple){ // reset previously selected node
                     const currentSelectedKey = this.flatState.findIndex(obj => obj.node.selected);
@@ -181,6 +182,7 @@
                 this.$emit('on-select-change', this.getSelectedNodes(), node);
             },
             handleCheck({ checked, nodeKey }) {
+                if (!this.flatState[nodeKey]) return
                 const node = this.flatState[nodeKey].node;
                 this.$set(node, 'checked', checked);
                 this.$set(node, 'indeterminate', false);

--- a/src/components/tree/tree.vue
+++ b/src/components/tree/tree.vue
@@ -171,7 +171,7 @@
                 }
             },
             handleSelect (nodeKey) {
-                if (!this.flatState[nodeKey]) return
+                if (!this.flatState[nodeKey]) return;
                 const node = this.flatState[nodeKey].node;
                 if (!this.multiple){ // reset previously selected node
                     const currentSelectedKey = this.flatState.findIndex(obj => obj.node.selected);
@@ -182,7 +182,7 @@
                 this.$emit('on-select-change', this.getSelectedNodes(), node);
             },
             handleCheck({ checked, nodeKey }) {
-                if (!this.flatState[nodeKey]) return
+                if (!this.flatState[nodeKey]) return;
                 const node = this.flatState[nodeKey].node;
                 this.$set(node, 'checked', checked);
                 this.$set(node, 'indeterminate', false);


### PR DESCRIPTION
例子：https://www.iviewui.com/components/tree#ZDYJDNR
删除最后一个节点时，控制台报错，找不到节点，因为被删除了。
