### PR TITLE
fix table fixed body style

### DIFF
--- a/src/components/table/table.vue
+++ b/src/components/table/table.vue
@@ -443,7 +443,13 @@
                 let style = {};
                 if (this.bodyHeight !== 0) {
                     let height = this.bodyHeight - (this.showHorizontalScrollBar?this.scrollBarWidth:0);
-                    style.height = this.showHorizontalScrollBar ? `${height}px` : `${height - 1}px`;
+					// style.height = this.showHorizontalScrollBar ? height + 'px' : height - 1 + 'px';
+					let heightPx = this.showHorizontalScrollBar ? height + 'px' : height - 1 + 'px';
+					if (this.height) {
+						style.height = heightPx;
+					} else if (this.maxHeight) {
+						style.maxHeight = heightPx;
+					}
                 }
                 return style;
             },


### PR DESCRIPTION
表格存在设置fixed时，且设置maxHeight后，在实际表格内容没有达到maxHeight时出现，fixedBody内容压盖横向滚轮，导致无法选中拖拽。

进行情况判断修改fixedBodyStyle样式