### PR TITLE
fix: 解决props为空，验证表单没响应的问题

### DIFF
--- a/examples/routers/form.vue
+++ b/examples/routers/form.vue
@@ -169,6 +169,24 @@
                     </FormItem>
                 </Form>
             </i-col>
+            <i-col span="6">
+                <Form :model="formValidate5" ref="formValidate5">
+                    <FormItem label="name" prop="name">
+                         <Input v-model="formValidate5.name" placeholder="Enter your name"></Input>
+                    </FormItem>
+                    <FormItem label="name">
+                        <i-switch v-model="formValidate5.msgCheck"  />
+                    </FormItem>
+                    <FormItem label="msg" v-if="formValidate5.msgCheck" prop="msg" :rules="[{
+                        required: true
+                    }]" >
+                         <Input v-model="formValidate5.msg" placeholder="msg"></Input>
+                    </FormItem>
+                    <FormItem>
+                        <Button type="primary" @click="handleSubmit('formValidate5')">Submit</Button>
+                    </FormItem>
+                </Form>
+            </i-col>
         </row>
         <div style="margin: 100px;width: 200px;">
             <Divider>普通组件</Divider>
@@ -283,6 +301,11 @@
                     inputNumber: 2,
                     rate: 3,
                     colorPicker: ''
+                },
+                formValidate5: {
+                    name: '',
+                    msgCheck: false,
+                    msg: ''
                 },
                 ruleValidate: {
                     name: [

--- a/src/components/form/form.vue
+++ b/src/components/form/form.vue
@@ -94,6 +94,9 @@
                     // fields 为空需要返回promise
                     if (this.fields.length === 0) {
                         resolve(valid);
+                        if (typeof callback === 'function') {
+                            callback(valid);
+                        }
                     }
                     this.fields.forEach(field => {
                         field.validate('', errors => {

--- a/src/components/form/form.vue
+++ b/src/components/form/form.vue
@@ -91,6 +91,10 @@
                 return new Promise(resolve => {
                     let valid = true;
                     let count = 0;
+                    // fields 为空需要返回promise
+                    if (this.fields.length === 0) {
+                        resolve(valid);
+                    }
                     this.fields.forEach(field => {
                         field.validate('', errors => {
                             if (errors) {


### PR DESCRIPTION
示例：
https://run.iviewui.com/0SKpjXx8

主要原因是 this.fields.length === 0 时，promise 没有处理