### PR TITLE
fix: 关闭最后一个标签页时报错

### DIFF
--- a/src/components/tabs/tabs.vue
+++ b/src/components/tabs/tabs.vue
@@ -292,7 +292,7 @@
                 setTimeout(() => this.transitioning = false, transitionTime);
 
                 const nav = this.navList[index];
-                if (nav.disabled) return;
+                if (!nav || nav.disabled) return;
                 this.activeKey = nav.name;
                 this.$emit('input', nav.name);
                 this.$emit('on-click', nav.name);


### PR DESCRIPTION
通过 v-for 生成标签页列表，不用 ViewUI 自带关闭，而是手动关闭最后一个标签页时，出现 TypeError: Cannot read property 'disabled' of undefined 异常。

<!-- 请提交 PR 到 master 分支 | Please send PR to master branch -->
<!-- 请不要提交 dist 的内容 | Please do not commit dist file -->
<!-- 请先运行 npm install 和 npm test，通过测试后再提交您的 pr -->
<!-- Please run `npm install` and `npm test` to test your changes before submitting a pull request -->
