### PR TITLE
修复低版本浏览器select组件在搜索时，按下backspace无法正确删除搜索关键字

### DIFF
--- a/src/components/select/select.vue
+++ b/src/components/select/select.vue
@@ -597,7 +597,8 @@
             },
             handleKeydown (e) {
                 const key = e.key || e.code;
-                if (key === 'Backspace'){
+                const keyCode = e.keyCode || e.which;
+                if (key === 'Backspace' || keyCode===8){
                     return; // so we don't call preventDefault
                 }
 


### PR DESCRIPTION
<!-- 请提交 PR 到 master 分支 | Please send PR to master branch -->
<!-- 请不要提交 dist 的内容 | Please do not commit dist file -->
<!-- 请先运行 npm install 和 npm test，通过测试后再提交您的 pr -->
<!-- Please run `npm install` and `npm test` to test your changes before submitting a pull request -->
由于低版本浏览器keydown的事件对象event中没有key或者code，导致无法正确删除关键字，低版本浏览器keydown的事件对象中应使用keyCode和which作为代替。