### PR TITLE
fix dropdown.vue scroll stuck problem

### DIFF
--- a/src/components/select/dropdown.vue
+++ b/src/components/select/dropdown.vue
@@ -52,6 +52,7 @@
                 } else {
                     this.$nextTick(() => {
                         this.popper = new Popper(this.$parent.$refs.reference, this.$el, {
+                            eventsEnabled: false,
                             placement: this.placement,
                             modifiers: {
                                 computeStyle:{


### PR DESCRIPTION
It is recommended to turn off scroll event monitoring for popper plug-in configuration, otherwise, if there are too many such components in a single page, the scroll bar of the page will be severely stuck; in fact, it only needs to be updated when the pop-up layer is displayed, and it does not need to be invisible or to update the position.

<!-- 请提交 PR 到 master 分支 | Please send PR to master branch -->
<!-- 请不要提交 dist 的内容 | Please do not commit dist file -->
<!-- 请先运行 npm install 和 npm test，通过测试后再提交您的 pr -->
<!-- Please run `npm install` and `npm test` to test your changes before submitting a pull request -->
