### PR TITLE
fix popper.js: Turn off scroll event monitoring to solve the problem …

### DIFF
--- a/src/components/base/popper.js
+++ b/src/components/base/popper.js
@@ -7,6 +7,10 @@ const Popper = isServer ? function() {} : require('popper.js/dist/umd/popper.js'
 
 export default {
     props: {
+        eventsEnabled: {
+            type: Boolean,
+            default: false
+        },
         placement: {
             type: String,
             default: 'bottom'
@@ -85,6 +89,8 @@ export default {
             if (this.popperJS && this.popperJS.hasOwnProperty('destroy')) {
                 this.popperJS.destroy();
             }
+            
+            options.eventsEnabled = this.eventsEnabled;
 
             options.placement = this.placement;
 


### PR DESCRIPTION
…of scroll lag

When there are more Tooltip components on the page, it is easy to cause the page scrolling to be severely stuck. It is recommended to close it by default.

<!-- 请提交 PR 到 master 分支 | Please send PR to master branch -->
<!-- 请不要提交 dist 的内容 | Please do not commit dist file -->
<!-- 请先运行 npm install 和 npm test，通过测试后再提交您的 pr -->
<!-- Please run `npm install` and `npm test` to test your changes before submitting a pull request -->
