### PR TITLE
dropdown.vue: fix Pooper created multiple times

### DIFF
--- a/src/components/select/dropdown.vue
+++ b/src/components/select/dropdown.vue
@@ -44,14 +44,13 @@
         methods: {
             update () {
                 if (isServer) return;
-                if (this.popper) {
-                    this.$nextTick(() => {
+                this.$nextTick(() => {
+                    if (this.popper) {
                         this.popper.update();
                         this.popperStatus = true;
-                    });
-                } else {
-                    this.$nextTick(() => {
+                    } else {
                         this.popper = new Popper(this.$parent.$refs.reference, this.$el, {
+                            eventsEnabled: false,
                             placement: this.placement,
                             modifiers: {
                                 computeStyle:{
@@ -69,13 +68,13 @@
                                 this.resetTransformOrigin();
                             }
                         });
-                    });
-                }
-                // set a height for parent is Modal and Select's width is 100%
-                if (this.$parent.$options.name === 'iSelect') {
-                    this.width = parseInt(getStyle(this.$parent.$el, 'width'));
-                }
-                this.tIndex = this.handleGetIndex();
+                    }
+                    // set a height for parent is Modal and Select's width is 100%
+                    if (this.$parent.$options.name === 'iSelect') {
+                        this.width = parseInt(getStyle(this.$parent.$el, 'width'));
+                    }
+                    this.tIndex = this.handleGetIndex();
+                });
             },
             destroy () {
                 if (this.popper) {


### PR DESCRIPTION
Fix the issue that the select component watch selectOptions causes Pooper to repeatedly create multiple times (the bound scroll event cannot be cleared), and the select component watch selectOptions is recommended to be throttled.

<!-- 请提交 PR 到 master 分支 | Please send PR to master branch -->
<!-- 请不要提交 dist 的内容 | Please do not commit dist file -->
<!-- 请先运行 npm install 和 npm test，通过测试后再提交您的 pr -->
<!-- Please run `npm install` and `npm test` to test your changes before submitting a pull request -->
