### PR TITLE
Table增加removeSortNormal属性,点击排序的列表头时仅asc,desc,默认false;

### DIFF
--- a/examples/routers/table.vue
+++ b/examples/routers/table.vue
@@ -80,6 +80,8 @@
         <Table border :columns="columns11" :data="data10" height="500"></Table>
         <Divider>筛选</Divider>
         <Table border :columns="columns6" :data="data5"></Table>
+        <Divider>排序表格(移除normal)</Divider>
+        <Table @on-sort-change="handleSortChange" :removeSortNormal="true" border :columns="columns6" :data="data5"></Table>
     </div>
 </template>
 <script>
@@ -947,6 +949,9 @@
                     _disabled: true,
                     level: 0
                 })
+            },
+            handleSortChange({ key, order }) {
+                console.log(key, order);
             }
         }
     }

--- a/src/components/table/table-head.vue
+++ b/src/components/table/table-head.vue
@@ -100,7 +100,11 @@
                 default: false
             },
             columnRows: Array,
-            fixedColumnRows: Array
+            fixedColumnRows: Array,
+            removeSortNormal: {
+                type: Boolean,
+                default: false
+            }
         },
         data () {
             return {
@@ -226,12 +230,20 @@
                 const column = this.columns.find(item => item._index === index);
                 if (column.sortable) {
                     const type = column._sortType;
-                    if (type === 'normal') {
-                        this.handleSort(index, 'asc');
-                    } else if (type === 'asc') {
-                        this.handleSort(index, 'desc');
+                    if (this.removeSortNormal) {
+                        if (type === "asc") {
+                            this.handleSort(index, "desc");
+                        } else {
+                            this.handleSort(index, "asc");
+                        }
                     } else {
-                        this.handleSort(index, 'normal');
+                        if (type === "normal") {
+                            this.handleSort(index, "asc");
+                        } else if (type === "asc") {
+                            this.handleSort(index, "desc");
+                        } else {
+                            this.handleSort(index, "normal");
+                        }
                     }
                 }
             },

--- a/src/components/table/table.vue
+++ b/src/components/table/table.vue
@@ -10,6 +10,7 @@
                     :column-rows="columnRows"
                     :obj-data="objData"
                     :columns-width="columnsWidth"
+                    :removeSortNormal="removeSortNormal"
                     :data="rebuildData"></table-head>
             </div>
             <div :class="[prefixCls + '-body']" :style="bodyStyle" ref="body" @scroll="handleBodyScroll"
@@ -281,6 +282,10 @@
             },
             // 4.2.0
             showContextMenu: {
+                type: Boolean,
+                default: false
+            },
+            removeSortNormal: {
                 type: Boolean,
                 default: false
             }


### PR DESCRIPTION
<!-- 请提交 PR 到 master 分支 | Please send PR to master branch -->
<!-- 请不要提交 dist 的内容 | Please do not commit dist file -->
<!-- 请先运行 npm install 和 npm test，通过测试后再提交您的 pr -->
<!-- Please run `npm install` and `npm test` to test your changes before submitting a pull request -->

demo位于/examples/table.vue
```html
        <Divider>排序表格(移除normal)</Divider>
        <Table @on-sort-change="handleSortChange" :removeSortNormal="true" border :columns="columns6" :data="data5"></Table>
```