### PR TITLE
fix#615 表格表头分组 点击头部最顶层报错

### DIFF
--- a/src/components/table/table-head.vue
+++ b/src/components/table/table-head.vue
@@ -18,7 +18,7 @@
                         </template>
                         <template v-else-if="column.type === 'selection'"><Checkbox :value="isSelectAll" :disabled="isSelectDisabled" @on-change="selectAll"></Checkbox></template>
                         <template v-else>
-                            <span v-if="!column.renderHeader" :class="{[prefixCls + '-cell-sort']: column.sortable}" @click="handleSortByHead(getColumn(rowIndex, index)._index)">{{ column.title || '#' }}</span>
+                            <span v-if="!column.renderHeader" :class="{[prefixCls + '-cell-sort']: column.sortable}" @click="column.sortable && handleSortByHead(getColumn(rowIndex, index)._index)">{{ column.title || '#' }}</span>
                             <render-header v-else :render="column.renderHeader" :column="column" :index="index"></render-header>
                             <span :class="[prefixCls + '-sort']" v-if="column.sortable">
                                 <i class="ivu-icon ivu-icon-md-arrow-dropup" :class="{on: getColumn(rowIndex, index)._sortType === 'asc'}" @click="handleSort(getColumn(rowIndex, index)._index, 'asc')"></i>


### PR DESCRIPTION
fixbug: [https://github.com/view-design/ViewUI/issues/615](https://github.com/view-design/ViewUI/issues/615)

报错截图：
![1](https://user-images.githubusercontent.com/11221788/89402573-ab046d80-d749-11ea-925f-36f0fbd61af1.png)
![2](https://user-images.githubusercontent.com/11221788/89402594-b192e500-d749-11ea-8d26-21377200a66a.png)

解决方案：增加判断，如果是设置`sortable`可以排序则可点击进入后面逻辑
