### PR TITLE
解决树形数据的table，row-class-name方法获取的row数据永远只是第一层的数据。

### DIFF
--- a/src/components/table/table-tr.vue
+++ b/src/components/table/table-tr.vue
@@ -31,15 +31,15 @@
                 const objData = this.isChildren ? this.$parent.$parent.getDataByRowKey(this.row._rowKey) : this.objData[_index];
                 return [
                     `${this.prefixCls}-row`,
-                    this.rowClsName(_index),
+                    this.rowClsName(objData, _index),
                     {
                         [`${this.prefixCls}-row-highlight`]: objData && objData._isHighlight,
                         [`${this.prefixCls}-row-hover`]: objData && objData._isHover
                     }
                 ];
             },
-            rowClsName (_index) {
-                return this.$parent.$parent.rowClassName(this.objData[_index], _index);
+            rowClsName (row, _index) {
+                return this.$parent.$parent.rowClassName(row, _index);
             },
         }
     };


### PR DESCRIPTION
修改后，tree型结构的数据，通过row-class-name方法返回的row参数，就不会只是第一层的数据，而是真正的对应着的每行数据。