### PR TITLE
Dropdown组件嵌套使用trigger

### DIFF
--- a/src/components/dropdown/dropdown.vue
+++ b/src/components/dropdown/dropdown.vue
@@ -113,7 +113,11 @@
                 if (this.trigger !== 'click') {
                     return false;
                 }
-                this.currentVisible = !this.currentVisible;
+                // this.currentVisible = !this.currentVisible;
+                var $parent = this.hasParent();
+                if (!$parent) {
+                    this.currentVisible = !this.currentVisible;
+                }
             },
             handleRightClick () {
                 if (this.trigger === 'custom') return false;

--- a/src/components/dropdown/dropdown.vue
+++ b/src/components/dropdown/dropdown.vue
@@ -113,11 +113,9 @@
                 if (this.trigger !== 'click') {
                     return false;
                 }
-                // this.currentVisible = !this.currentVisible;
-                var $parent = this.hasParent();
-                if (!$parent) {
-                    this.currentVisible = !this.currentVisible;
-                }
+                // #661
+                const $parent = this.hasParent();
+                if (!$parent) this.currentVisible = !this.currentVisible;
             },
             handleRightClick () {
                 if (this.trigger === 'custom') return false;


### PR DESCRIPTION
### 嵌套使用时**trigger都是click**,子级先出现后消失
```
     <Dropdown trigger="click"> //父级click
        <a href="javascript:void(0)">
            北京小吃
            <Icon type="ios-arrow-down"></Icon>
        </a>
        <DropdownMenu slot="list">
            <DropdownItem>驴打滚</DropdownItem>
            <DropdownItem>炸酱面</DropdownItem>
            <DropdownItem>豆汁儿</DropdownItem>
            <Dropdown placement="right-start" trigger="click"> //子级click
                <DropdownItem>
                    北京烤鸭
                    <Icon type="ios-arrow-forward"></Icon>
                </DropdownItem>
                <DropdownMenu slot="list">
                    <DropdownItem>挂炉烤鸭</DropdownItem>
                    <DropdownItem>焖炉烤鸭</DropdownItem>
                </DropdownMenu>
            </Dropdown>
            <DropdownItem>冰糖葫芦</DropdownItem>
        </DropdownMenu>
    </Dropdown>
```
