### PR TITLE
fix: Drawer内使用Modal，导致主页面可滑动，出现两个滑动条

### DIFF
--- a/src/components/modal/confirm.js
+++ b/src/components/modal/confirm.js
@@ -100,6 +100,7 @@ Modal.newInstance = properties => {
                 props: Object.assign({}, _props, {
                     width: this.width,
                     scrollable: this.scrollable,
+                    inDrawer: this.inDrawer,
                     closable: this.closable
                 }),
                 domProps: {
@@ -259,6 +260,9 @@ Modal.newInstance = properties => {
                 modal.$parent.scrollable = props.scrollable;
             }
 
+            if ('inDrawer' in props) {
+                modal.$parent.inDrawer = props.inDrawer;
+            }
             // notice when component destroy
             modal.$parent.onRemove = props.onRemove;
 

--- a/src/components/modal/modal.vue
+++ b/src/components/modal/modal.vue
@@ -123,6 +123,10 @@
                 type: Boolean,
                 default: false
             },
+            inDrawer: {
+                type: Boolean,
+                default: false
+            },
             zIndex: {
                 type: Number,
                 default: 1000
@@ -365,7 +369,9 @@
         },
         beforeDestroy () {
             document.removeEventListener('keydown', this.EscClose);
-            this.removeScrollEffect();
+            if (!this.inDrawer) {
+                this.removeScrollEffect();
+            }
         },
         watch: {
             value (val) {
@@ -376,7 +382,9 @@
                     this.buttonLoading = false;
                     this.timer = setTimeout(() => {
                         this.wrapShow = false;
-                        this.removeScrollEffect();
+                        if (!this.inDrawer) {
+                            this.removeScrollEffect();
+                        }
                     }, 300);
                 } else {
                     this.modalIndex = this.handleGetModalIndex();
@@ -400,7 +408,9 @@
                 if (!val) {
                     this.addScrollEffect();
                 } else {
-                    this.removeScrollEffect();
+                    if (!this.inDrawer) {
+                        this.removeScrollEffect();
+                    }
                 }
             },
             title (val) {


### PR DESCRIPTION
在Drawer内使用Modal的confirm时
不管确定还是取消都会调用removeScrollEffect把body的overflow去掉
导致主页面可滑动，出现两个滑动条