### PR TITLE
fix filterMethod type in TableColumn

### DIFF
--- a/types/table.d.ts
+++ b/types/table.d.ts
@@ -312,7 +312,7 @@ export declare class TableColumn {
     /**
      * 数据过滤使用的方法，如果是多选的筛选项，对每一条数据会执行多次，任意一次返回 true 就会显示
      */
-    filterMethod?: () => void;
+    filterMethod?: (value: any, row: any) => boolean;
     /**
      * 数据过滤的选项是否多选
      * @default true


### PR DESCRIPTION
I think `filterMethod` type declaration in `TableColumn` class is incorrect. It takes two arguments `value` & `row`, and returns boolean.
[Filter in table - iView](https://www.iviewui.com/components/table-en#Filter)