### PR TITLE
fix #486 scroll shaking bug

### DIFF
--- a/src/components/scroll/scroll.vue
+++ b/src/components/scroll/scroll.vue
@@ -86,7 +86,12 @@
                 return `${prefixCls}-wrapper`;
             },
             scrollContainerClasses() {
-                return `${prefixCls}-container`;
+                return [
+                    `${prefixCls}-container`,
+                    {
+                        [`${prefixCls}-container-loading`]: this.showBodyLoader
+                    }
+                ];
             },
             slotContainerClasses() {
                 return [

--- a/src/styles/components/scroll.less
+++ b/src/styles/components/scroll.less
@@ -12,6 +12,19 @@
 		overflow-y: scroll;
 	}
 
+    @keyframes ani-stop-slide {
+        from {
+            overflow-y: hidden;
+        }
+        to {
+            overflow-y: scroll;
+        }
+    }
+
+    &-container-loading {
+        animation: ani-stop-slide 1s;
+    }
+
 	&-content {
 		opacity: 1;
 		transition: opacity 0.5s;


### PR DESCRIPTION
<!-- 请提交 PR 到 master 分支 | Please send PR to master branch -->
<!-- 如果试图解决一个问题，请附上能够最小化复现问题的 run.iviewui.com 链接 -->
<!-- 请不要提交 dist 的内容 | Please do not commit dist file -->
<!-- 请先运行 npm install 和 npm test，通过测试后再提交您的 pr -->
<!-- Please run `npm install` and `npm test` to test your changes before submitting a pull request -->

【修复#486   scroll 组件触底事件触发的同时，向上滑动滚轮，页面出现长时间抖动问题】
https://github.com/view-design/ViewUI/issues/486

【复现】
https://run.iviewui.com/hkWmUonR
handleReachBottom 的 setTimeout 改为一个很短的时间，发生明显抖动

【bug原因】
src/components/scroll/scroll.vue:155
设置container.scrollTop时候如果滚动鼠标就会造成抖动

【解决方案】
loading状态 前1秒中禁止  .ivu-scroll-container  滚动


