### PR TITLE
fix: Tree performance issues

### DIFF
--- a/src/components/tree/node.vue
+++ b/src/components/tree/node.vue
@@ -18,7 +18,8 @@
                     <template v-else>{{ data.title }}</template>
                 </span>
                 <Tree-node
-                        v-if="data.expand"
+                        v-if="childNodeRendered"
+                        v-show="data.expand"
                         :appear="appearByClickArrow"
                         v-for="(item, i) in children"
                         :key="i"
@@ -73,8 +74,19 @@
         data () {
             return {
                 prefixCls: prefixCls,
-                appearByClickArrow: false
+                appearByClickArrow: false,
+                childNodeRendered: false
             };
+        },
+        watch:{
+            'data.expand':{
+                immediate: true,
+                handler(val) {
+                    if (val) {
+                        this.childNodeRendered = true;
+                    }
+                }
+            }
         },
         computed: {
             classes () {

--- a/src/components/tree/tree.vue
+++ b/src/components/tree/tree.vue
@@ -116,10 +116,18 @@
             compileFlatState () { // so we have always a relation parent/children of each node
                 let keyCounter = 0;
                 let childrenKey = this.childrenKey;
-                const flatTree = [];
+                let flatTree = [];
+                if(this.flatState.length!==0){
+                    flatTree = this.flatState;
+                }
                 function flattenChildren(node, parent) {
                     node.nodeKey = keyCounter++;
-                    flatTree[node.nodeKey] = { node: node, nodeKey: node.nodeKey };
+                    if(flatTree[node.nodeKey]){
+                        flatTree[node.nodeKey].node = node;
+                        flatTree[node.nodeKey].nodeKey = node.nodeKey;
+                    }else{
+                        flatTree[node.nodeKey] = { node: node, nodeKey: node.nodeKey };
+                    }
                     if (typeof parent != 'undefined') {
                         flatTree[node.nodeKey].parent = parent.nodeKey;
                         flatTree[parent.nodeKey][childrenKey].push(node.nodeKey);


### PR DESCRIPTION
【修复Tree组件使用render方式,(展开/选中...)节点等会导致重新渲染所有节点】

【复现】
https://run.iviewui.com/L6evA8Da
(展开/选中...)节点会重新render当前可视的所有节点

【bug原因】
src/components/tree/tree.vue
节点展开后会变触发data的watch,里面重新赋值了flatState, render中会保持对flatState的更新,导致所有render重新执行