### PR TITLE
fix: 修复avatar组件在部分缩放比例下出现页面卡死 #116

### DIFF
--- a/src/components/avatar/avatar.vue
+++ b/src/components/avatar/avatar.vue
@@ -45,7 +45,8 @@
                 prefixCls: prefixCls,
                 scale: 1,
                 childrenWidth: 0,
-                isSlotShow: false
+                isSlotShow: false,
+                slotTemp: null
             };
         },
         computed: {
@@ -85,6 +86,11 @@
                 return style;
             }
         },
+        watch: {
+            size: function (val, oldVal) {
+                if (val !== oldVal) this.setScale();
+            },
+        },
         methods: {
             setScale () {
                 this.isSlotShow = !this.src && !this.icon;
@@ -104,11 +110,17 @@
                 this.$emit('on-error', e);
             }
         },
+        beforeCreate () {
+		    this.slotTemp = this.$slots.default;
+	    },
         mounted () {
             this.setScale();
         },
         updated () {
-            this.setScale();
+            if (this.$slots.default !== this.slotTemp) {
+                this.slotTemp = this.$slots.default;
+                this.setScale();
+            }
         }
     };
 </script>

--- a/src/components/avatar/avatar.vue
+++ b/src/components/avatar/avatar.vue
@@ -87,9 +87,9 @@
             }
         },
         watch: {
-            size: function (val, oldVal) {
+            size (val, oldVal) {
                 if (val !== oldVal) this.setScale();
-            },
+            }
         },
         methods: {
             setScale () {


### PR DESCRIPTION
修复调整缩放比例，刷新页面，导致无限更新this.scale，出现卡死状况

<!-- 请提交 PR 到 master 分支 | Please send PR to master branch -->
<!-- 如果试图解决一个问题，请附上能够最小化复现问题的 run.iviewui.com 链接 -->
<!-- 请不要提交 dist 的内容 | Please do not commit dist file -->
<!-- 请先运行 npm install 和 npm test，通过测试后再提交您的 pr -->
<!-- Please run `npm install` and `npm test` to test your changes before submitting a pull request -->
