### PR TITLE
feat: #871 Dropdown 在 transfer 时, 极难控制原生点击事件冒泡

### DIFF
--- a/src/components/dropdown/dropdown.vue
+++ b/src/components/dropdown/dropdown.vue
@@ -61,6 +61,11 @@
                 type: Boolean,
                 default: false
             },
+            // feat: #871 无法控制原生事件冒泡
+            stopNativePropagation: {
+                type: Boolean,
+                default: false
+            },
             // 4.0.0
             capture: {
                 type: Boolean,
@@ -108,7 +113,8 @@
             }
         },
         methods: {
-            handleClick () {
+            handleClick (event) {
+                if(this.stopNativePropagation) event.stopPropagation();
                 if (this.trigger === 'custom') return false;
                 if (this.trigger !== 'click') {
                     return false;
@@ -175,6 +181,7 @@
         },
         mounted () {
             this.$on('on-click', (key) => {
+                // feat: #871 无法控制原生事件冒泡
                 if (this.stopPropagation) return;
                 const $parent = this.hasParent();
                 if ($parent) $parent.$emit('on-click', key);


### PR DESCRIPTION
<!-- 请提交 PR 到 master 分支 | Please send PR to master branch -->
<!-- 如果试图解决一个问题，请附上能够最小化复现问题的 run.iviewui.com 链接 -->
<!-- 请不要提交 dist 的内容 | Please do not commit dist file -->
<!-- 请先运行 npm install 和 npm test，通过测试后再提交您的 pr -->
<!-- Please run `npm install` and `npm test` to test your changes before submitting a pull request -->
方案1: 新增 stopNativePropagation
#871 
