### PR TITLE
Drawer mask的点击关闭触发事件应该改成mousedown，因为click会有一些体验问题

### DIFF
--- a/src/components/drawer/drawer.vue
+++ b/src/components/drawer/drawer.vue
@@ -1,7 +1,7 @@
 <template>
     <div v-transfer-dom :data-transfer="transfer">
         <transition name="fade">
-            <div :class="maskClasses" :style="maskStyle" v-show="visible" v-if="mask" @click="handleMask"></div>
+            <div :class="maskClasses" :style="maskStyle" v-show="visible" v-if="mask" @mousedown="handleMask"></div>
         </transition>
         <div :class="wrapClasses" @click="handleWrapClick">
             <transition :name="transitionName">


### PR DESCRIPTION
如果Drawer组件开启了mask-closable选项，在里放了一个文本框，用鼠标按下拖拉选中文本框中的文字，鼠标移到Drawer mask区域再放开，这时便会触发mask的点击关闭事件，导致Drawer被关闭，体验很不好，或者在Drawer组件里有水平滚动的区域，鼠标拖动滚动条时也会有这样的问题
https://run.iviewui.com/NfYZ6Y02

<!-- 请提交 PR 到 master 分支 | Please send PR to master branch -->
<!-- 如果试图解决一个问题，请附上能够最小化复现问题的 run.iviewui.com 链接 -->
<!-- 请不要提交 dist 的内容 | Please do not commit dist file -->
<!-- 请先运行 npm install 和 npm test，通过测试后再提交您的 pr -->
<!-- Please run `npm install` and `npm test` to test your changes before submitting a pull request -->
