### PR TITLE
daterange现有api无法实现限制时间周期范围的最大值

### DIFF
--- a/src/components/date-picker/base/mixin.js
+++ b/src/components/date-picker/base/mixin.js
@@ -47,7 +47,7 @@ export default {
             const newDate = new Date(clearHours(cell.date));
 
             this.$emit('on-pick', newDate);
-            this.$emit('on-pick-click');
+            this.$emit('on-pick-click', newDate);
         },
         handleMouseMove (cell) {
             if (!this.rangeState.selecting) return;

--- a/src/components/date-picker/panel/panel-mixin.js
+++ b/src/components/date-picker/panel/panel-mixin.js
@@ -28,8 +28,8 @@ export default {
             this.resetView();
             this.$emit('on-pick-success');
         },
-        handlePickClick () {
-            this.$emit('on-pick-click');
+        handlePickClick (e) {
+            this.$emit('on-pick-click', e);
         },
         resetView(){
             setTimeout(

--- a/src/components/date-picker/picker.vue
+++ b/src/components/date-picker/picker.vue
@@ -67,7 +67,7 @@
                         @on-pick="onPick"
                         @on-pick-clear="handleClear"
                         @on-pick-success="onPickSuccess"
-                        @on-pick-click="disableClickOutSide = true"
+                        @on-pick-click="onPickClick"
                         @on-selection-mode-change="onSelectionModeChange"
                     ></component>
                 </div>
@@ -375,6 +375,10 @@
             }
         },
         methods: {
+            onPickClick(e) {
+                this.disableClickOutSide = true
+                this.$emit('on-pick-click', e)
+            },
             onSelectionModeChange(type){
                 if (type.match(/^date/)) type = 'date';
                 this.selectionMode = oneOf(type, ['year', 'month', 'date', 'time']) && type;


### PR DESCRIPTION
场景描述： 只能选择1年的时间范围,用户选择了2021/06/01,  那么结束时间只能是2021/06/01~2022/06/01之间的时间

当前问题： 无法获取用户选择的开始时间是什么? 