### PR TITLE
在Select组件中触发on-enter事件

### DIFF
--- a/src/components/select/select.vue
+++ b/src/components/select/select.vue
@@ -48,7 +48,7 @@
                     @on-input-focus="isFocused = true"
                     @on-input-blur="isFocused = false"
                     @on-clear="clearSingleSelect"
-                    @on-enter="handleCreateItem"
+                    @on-enter="onEnter"
                 >
                     <slot name="prefix" slot="prefix"></slot>
                 </select-head>
@@ -807,6 +807,10 @@
                         this.$nextTick(() => this.onOptionClick(option));
                     }
                 }
+            },
+            onEnter() {
+                this.$emit('on-enter');
+                this.handleCreateItem();
             }
         },
         watch: {


### PR DESCRIPTION
将select-head中的on-enter事件在Select中触发，这在使用可搜索下拉框时，通过键盘选中选项，需要按回车进行确认或其他操作时会很有用

<!-- 请提交 PR 到 master 分支 | Please send PR to master branch -->
<!-- 如果试图解决一个问题，请附上能够最小化复现问题的 run.iviewui.com 链接 -->
<!-- 请不要提交 dist 的内容 | Please do not commit dist file -->
<!-- 请先运行 npm install 和 npm test，通过测试后再提交您的 pr -->
<!-- Please run `npm install` and `npm test` to test your changes before submitting a pull request -->
