### PR TITLE
fix: 修复Table中show-summary、fixed同时存在，且max-height设置的比实际高度高的时候，合计被顶出去的问题

### DIFF
--- a/src/components/table/table.vue
+++ b/src/components/table/table.vue
@@ -497,7 +497,12 @@
                 let style = {};
                 if (this.bodyHeight !== 0) {
                     let height = this.bodyHeight - (this.showHorizontalScrollBar?this.scrollBarWidth:0);
-                    style.height = this.showHorizontalScrollBar ? `${height}px` : `${height - 1}px`;
+                    if(this.height) {
+                        style.height = this.showHorizontalScrollBar ? `${height}px` : `${height - 1}px`;
+                    } else if (this.maxHeight) {
+                        style.maxHeight = this.showHorizontalScrollBar ? `${height}px` : `${height - 1}px`;
+                    }
+                    
                 }
                 return style;
             },

--- a/src/components/table/table.vue
+++ b/src/components/table/table.vue
@@ -497,12 +497,9 @@
                 let style = {};
                 if (this.bodyHeight !== 0) {
                     let height = this.bodyHeight - (this.showHorizontalScrollBar?this.scrollBarWidth:0);
-                    if(this.height) {
-                        style.height = this.showHorizontalScrollBar ? `${height}px` : `${height - 1}px`;
-                    } else if (this.maxHeight) {
-                        style.maxHeight = this.showHorizontalScrollBar ? `${height}px` : `${height - 1}px`;
-                    }
-                    
+                    const bodyHeight = this.showHorizontalScrollBar ? `${height}px` : `${height - 1}px`;
+                    if (this.height) style.height = bodyHeight;
+                    else if (this.maxHeight) style.maxHeight = bodyHeight;
                 }
                 return style;
             },


### PR DESCRIPTION

解决show-summary、fixed同时存在，且max-height设置的比实际高度高的时候，合计被顶出去的问题。

https://codepen.io/followfire/pen/dyRJLER
