### PR TITLE
fix(Scroll): 修复loading-component组件的模板被编译成纯html的问题

### DIFF
--- a/src/components/scroll/loading-component.vue
+++ b/src/components/scroll/loading-component.vue
@@ -1,4 +1,4 @@
-<template lang="html">
+<template>
     <div :class="wrapperClasses">
         <div :class="spinnerClasses">
             <Spin fix>


### PR DESCRIPTION
在本地打包编译时，最终生成的iview.js中，loading-component的模板被直接编译成了html，导致出现以下情况：
![image](https://user-images.githubusercontent.com/20350835/138020636-eee5b5ed-6feb-46db-bb8d-0761d4648901.png)


