### PR TITLE
fix: add notranslate class in page component

### DIFF
--- a/src/components/page/page.vue
+++ b/src/components/page/page.vue
@@ -191,6 +191,7 @@
                 return [
                     `${prefixCls}`,
                     `${prefixCls}-simple`,
+                    'notranslate',
                     {
                         [`${this.className}`]: !!this.className
                     }
@@ -202,6 +203,7 @@
             wrapClasses () {
                 return [
                     `${prefixCls}`,
+                    'notranslate',
                     {
                         [`${this.className}`]: !!this.className,
                         [`${prefixCls}-with-disabled`]: this.disabled,


### PR DESCRIPTION
https://github.com/view-design/ViewUI/issues/1018

Add notranslate class to ignore Page component when using chrome translate plugin