### PR TITLE
යාවත්කාල කිරීම

### DIFF
--- a/src/locale/lang/si_LK.js
+++ b/src/locale/lang/si_LK.js
@@ -10,7 +10,7 @@ const lang = {
         },
         table: {
             noDataText: 'දත්ත නැත',
-            noFilteredDataText: 'පෙරහන් දත්ත නොමැත',
+            noFilteredDataText: 'පෙරහන් දත්ත නැත',
             confirmFilter: 'තහවුරු කරන්න',
             resetFilter: 'යළි පිහිටුවන්න',
             clearFilter: 'සියල්ල',
@@ -69,7 +69,7 @@ const lang = {
                 target: 'ඉලක්කය'
             },
             filterPlaceholder: 'මෙතැන සොයන්න',
-            notFoundText: 'සොයා ගත  නොහැක'
+            notFoundText: 'හමු නොවිණි'
         },
         modal: {
             okText: 'හරි',


### PR DESCRIPTION
**What's new in this PR?**
Minor fixes

@icarusion Do you really need to follow **ex-xx** language code format?
- This leads to rise language versions and those are usually come with loan words from one or more other languages and several synonyms difference
- Appear insignificant grammar structures among people
- Effect to core languages quality with time
- When arise versions then affect to indigenous languages in countries.
- Also, loss contributors for each languages due they split into groups and that result to slow down localization speed.

So, you can use **ex-xx** format only if it essential and high-demand